### PR TITLE
use Vector to have the best Python 2&3 compatibility

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/regression/IsotonicRegression.scala
@@ -28,12 +28,13 @@ import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 
+import org.apache.spark.SparkContext
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.api.java.{JavaDoubleRDD, JavaRDD}
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.util.{Loader, Saveable}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.SQLContext
 
 /**
  * :: Experimental ::
@@ -139,6 +140,12 @@ class IsotonicRegressionModel (
       predictions(foundIndex)
     }
   }
+
+  /** A convenient method for boundaries called by the Python API. */
+  private[mllib] def boundaryVector: Vector = Vectors.dense(boundaries)
+
+  /** A convenient method for boundaries called by the Python API. */
+  private[mllib] def predictionVector: Vector = Vectors.dense(predictions)
 
   override def save(sc: SparkContext, path: String): Unit = {
     IsotonicRegressionModel.SaveLoadV1_0.save(sc, path, boundaries, predictions, isotonic)

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -445,17 +445,16 @@ class IsotonicRegressionModel(Saveable, Loader):
     def load(cls, sc, path):
         java_model = sc._jvm.org.apache.spark.mllib.regression.IsotonicRegressionModel.load(
             sc._jsc.sc(), path)
-        py_boundaries = _java2py(sc, java_model.boundaries())
-        py_predictions = _java2py(sc, java_model.predictions())
-        return IsotonicRegressionModel(np.array(py_boundaries),
-                                       np.array(py_predictions), java_model.isotonic)
+        py_boundaries = _java2py(sc, java_model.boundaryVector()).toArray()
+        py_predictions = _java2py(sc, java_model.predictionVector()).toArray()
+        return IsotonicRegressionModel(py_boundaries, py_predictions, java_model.isotonic)
 
 
 class IsotonicRegression(object):
     """
     Run IsotonicRegression algorithm to obtain isotonic regression model.
 
-    :param data:            RDD of data points
+    :param data:            RDD of (label, feature, weight) tuples.
     :param isotonic:        Whether this is isotonic or antitonic.
     """
     @classmethod
@@ -463,7 +462,7 @@ class IsotonicRegression(object):
         """Train a isotonic regression model on the given data."""
         boundaries, predictions = callMLlibFunc("trainIsotonicRegressionModel",
                                                 data.map(_convert_to_vector), bool(isotonic))
-        return IsotonicRegressionModel(np.array(boundaries), np.array(predictions), isotonic)
+        return IsotonicRegressionModel(boundaries.toArray(), predictions.toArray(), isotonic)
 
 
 def _test():


### PR DESCRIPTION
There is an issue with our SerDe for arrays in our Python 3. This PR switches to `Vector` for serialization.
